### PR TITLE
Fix missing grunt dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
         "url": "https://github.com/yoksel/svg-modify"
     },
     "author": "yoksel",
-    "license": "MIT"
+    "license": "MIT",
+    "dependencies": {
+        "grunt": "^1.0.2"
+    }
 }


### PR DESCRIPTION
This fixes issue #2 for the missing grunt dependency. Now when the user types npm install grunt will be installed to the current directory.